### PR TITLE
fix: Added tenant selection for retrieving and displaying contexts

### DIFF
--- a/nodes/continue.html
+++ b/nodes/continue.html
@@ -41,6 +41,11 @@
   </div>
 
   <div class="form-row">
+    <label for="node-input-tenant_name"><i class="fa fa-building"></i> Tenant</label>
+    <select id="node-input-tenant_name"></select>
+  </div>
+  
+  <div class="form-row">
     <label for="node-input-context"><i class="fa fa-road"></i> Context</label>
     <select id="node-input-context"></select>
   </div>


### PR DESCRIPTION
When we display the continue node, no context is selectable, this is due to the fact that the tenant is not defined.