### PR TITLE
fix auth token expiration on websocket

### DIFF
--- a/nodes/lib/internal_api.js
+++ b/nodes/lib/internal_api.js
@@ -114,6 +114,10 @@ const getVoicemail = async (url, token, tenant_uuid) => {
   return fetchAPI(url, token, tenant_uuid);
 };
 
+const getToken = async (url, token) => {
+  return fetchAPI(`${url}/${token}`, token);
+};
+
 const sendFax = async (url, token, context, extension, fax_content, caller_id, tenant_uuid) => {
   const params = new URLSearchParams({ context, extension, caller_id }).toString();
   const faxUrl = `${url}/api/calld/1.0/faxes?${params}`;
@@ -191,6 +195,7 @@ module.exports = {
   apiRequest,
   continueInDialplan,
   createNodeAddCall,
+  getToken,
   getVoicemail,
   hangupCall,
   initiateCallUser,


### PR DESCRIPTION
The token renewing has never worked in the websocket, this patch fix this issue. The result is now websocket will received all the time the events.